### PR TITLE
Add extra lead info fields

### DIFF
--- a/Backend/controllers/leads.js
+++ b/Backend/controllers/leads.js
@@ -48,7 +48,19 @@ const getLeads = async (req, res) => {
 };
 
 const addLead = async (req, res) => {
-  const { fullName, email, phone, notes, team_id } = req.body;
+  const {
+    fullName,
+    email,
+    phone,
+    altNumber,
+    notes,
+    deematAccountName,
+    profession,
+    stateName,
+    capital,
+    segment,
+    team_id
+  } = req.body;
   const { role, user_id } = req.query;
 
   if (!fullName || !email || !phone) {
@@ -78,10 +90,23 @@ const addLead = async (req, res) => {
     const safeAssignedTo = assignedTo && assignedTo.trim() !== '' ? assignedTo : null;
 
     const result = await pool.query(
-      `INSERT INTO leads (full_name, email, phone, notes, team_id, assigned_to)
-       VALUES ($1, $2, $3, $4, $5, $6)
+      `INSERT INTO leads (full_name, email, phone, alt_number, notes, deemat_account_name, profession, state_name, capital, segment, team_id, assigned_to)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
-      [fullName, email, phoneNorm, notes || '', safeTeamId, safeAssignedTo]
+      [
+        fullName,
+        email,
+        phoneNorm,
+        altNumber || '',
+        notes || '',
+        deematAccountName || '',
+        profession || '',
+        stateName || '',
+        capital || '',
+        segment || '',
+        safeTeamId,
+        safeAssignedTo
+      ]
     );
     res.status(201).json(result.rows[0]);
   } catch (err) {
@@ -92,7 +117,21 @@ const addLead = async (req, res) => {
 
 const updateLead = async (req, res) => {
   const { id } = req.params;
-  const { fullName, email, phone, notes, status, team_id, assigned_to } = req.body;
+  const {
+    fullName,
+    email,
+    phone,
+    altNumber,
+    notes,
+    deematAccountName,
+    profession,
+    stateName,
+    capital,
+    segment,
+    status,
+    team_id,
+    assigned_to
+  } = req.body;
 
   if (!fullName || !email || !phone || !status) {
     return res.status(400).json({ error: 'Missing required fields' });
@@ -106,10 +145,36 @@ const updateLead = async (req, res) => {
   try {
     const result = await pool.query(
       `UPDATE leads
-       SET full_name = $1, email = $2, phone = $3, notes = $4, status = $5,
-           team_id = $6, assigned_to = $7
-       WHERE id = $8 RETURNING *`,
-      [fullName, email, phoneNorm, notes || '', status, safeTeamId, safeAssignedTo, id]
+       SET full_name = $1,
+           email = $2,
+           phone = $3,
+           alt_number = $4,
+           notes = $5,
+           deemat_account_name = $6,
+           profession = $7,
+           state_name = $8,
+           capital = $9,
+           segment = $10,
+           status = $11,
+           team_id = $12,
+           assigned_to = $13
+       WHERE id = $14 RETURNING *`,
+      [
+        fullName,
+        email,
+        phoneNorm,
+        altNumber || '',
+        notes || '',
+        deematAccountName || '',
+        profession || '',
+        stateName || '',
+        capital || '',
+        segment || '',
+        status,
+        safeTeamId,
+        safeAssignedTo,
+        id
+      ]
     );
     res.json(result.rows[0]);
   } catch (err) {
@@ -182,7 +247,13 @@ const uploadLeads = [
         const fullName = row['Full Name'] || row.fullName || '';
         const email = row['Email'] || row.email || '';
         const phone = normalizePhone(row['Phone'] || row.phone || '');
+        const altNumber = row['Alternate Number'] || row.altNumber || '';
         const notes = row['Notes'] || row.notes || '';
+        const deematAccountName = row['Deemat Account Name'] || row.deematAccountName || '';
+        const profession = row['Profession'] || row.profession || '';
+        const stateName = row['State Name'] || row.stateName || '';
+        const capital = row['Capital'] || row.capital || '';
+        const segment = row['Segment'] || row.segment || '';
         const team_id = row['Team ID'] || row.team_id || null;
 
         const safeTeamId = team_id && team_id.trim() !== '' ? team_id : null;
@@ -192,9 +263,21 @@ const uploadLeads = [
         if (sheetPhones.has(phone)) continue;
 
         await client.query(
-          `INSERT INTO leads (full_name, email, phone, notes, team_id)
-           VALUES ($1, $2, $3, $4, $5)`,
-          [fullName, email, phone, notes, safeTeamId]
+          `INSERT INTO leads (full_name, email, phone, alt_number, notes, deemat_account_name, profession, state_name, capital, segment, team_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+          [
+            fullName,
+            email,
+            phone,
+            altNumber,
+            notes,
+            deematAccountName,
+            profession,
+            stateName,
+            capital,
+            segment,
+            safeTeamId
+          ]
         );
 
         sheetPhones.add(phone);
@@ -249,7 +332,13 @@ const googleSheetsUpload = async (req, res) => {
         const fullName = row['Full Name'] || row.fullName || '';
         const email = row['Email'] || row.email || '';
         const phone = normalizePhone(row['Phone'] || row.phone || '');
+        const altNumber = row['Alternate Number'] || row.altNumber || '';
         const notes = row['Notes'] || row.notes || '';
+        const deematAccountName = row['Deemat Account Name'] || row.deematAccountName || '';
+        const profession = row['Profession'] || row.profession || '';
+        const stateName = row['State Name'] || row.stateName || '';
+        const capital = row['Capital'] || row.capital || '';
+        const segment = row['Segment'] || row.segment || '';
         const team_id = row['Team ID'] || row.team_id || null;
 
         const safeTeamId = team_id && team_id.trim() !== '' ? team_id : null;
@@ -259,9 +348,21 @@ const googleSheetsUpload = async (req, res) => {
         if (sheetPhones.has(phone)) continue;
 
         await client.query(
-          `INSERT INTO leads (full_name, email, phone, notes, team_id)
-           VALUES ($1, $2, $3, $4, $5)`,
-          [fullName, email, phone, notes, safeTeamId]
+          `INSERT INTO leads (full_name, email, phone, alt_number, notes, deemat_account_name, profession, state_name, capital, segment, team_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+          [
+            fullName,
+            email,
+            phone,
+            altNumber,
+            notes,
+            deematAccountName,
+            profession,
+            stateName,
+            capital,
+            segment,
+            safeTeamId
+          ]
         );
 
         sheetPhones.add(phone);

--- a/src/components/modals/LeadModal.tsx
+++ b/src/components/modals/LeadModal.tsx
@@ -24,7 +24,13 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
     fullName: '',
     phone: '',
     email: '',
+    altNumber: '',
     notes: '',
+    deematAccountName: '',
+    profession: '',
+    stateName: '',
+    capital: '',
+    segment: '',
     status: 'New',
     team_id: '',
   });
@@ -40,7 +46,13 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
         fullName: lead.fullName || '',
         phone: lead.phone || '',
         email: lead.email || '',
+        altNumber: lead.altNumber || '',
         notes: lead.notes || '',
+        deematAccountName: lead.deematAccountName || '',
+        profession: lead.profession || '',
+        stateName: lead.stateName || '',
+        capital: lead.capital || '',
+        segment: lead.segment || '',
         status: lead.status || 'New',
         team_id: lead.team_id || '',
       });
@@ -49,7 +61,13 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
         fullName: '',
         phone: '',
         email: '',
+        altNumber: '',
         notes: '',
+        deematAccountName: '',
+        profession: '',
+        stateName: '',
+        capital: '',
+        segment: '',
         status: 'New',
         team_id: '',
       });
@@ -131,6 +149,109 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.email}
             onChange={handleChange}
             required
+          />
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">Alternate Number</label>
+          <input
+            type="text"
+            name="altNumber"
+            className="form-input"
+            value={formData.altNumber}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">Deemat Account Name</label>
+          <select
+            name="deematAccountName"
+            className="form-input"
+            value={formData.deematAccountName}
+            onChange={handleChange}
+          >
+            <option value="">Select</option>
+            <option value="Zerodha">Zerodha</option>
+            <option value="Upstox">Upstox</option>
+            <option value="Angel One">Angel One</option>
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">Profession</label>
+          <select
+            name="profession"
+            className="form-input"
+            value={formData.profession}
+            onChange={handleChange}
+          >
+            <option value="">Select</option>
+            <option value="Student">Student</option>
+            <option value="Private Sector">Private Sector</option>
+            <option value="Business">Business</option>
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">State</label>
+          <select
+            name="stateName"
+            className="form-input"
+            value={formData.stateName}
+            onChange={handleChange}
+          >
+            <option value="">Select</option>
+            <option value="Andhra Pradesh">Andhra Pradesh</option>
+            <option value="Arunachal Pradesh">Arunachal Pradesh</option>
+            <option value="Assam">Assam</option>
+            <option value="Bihar">Bihar</option>
+            <option value="Chhattisgarh">Chhattisgarh</option>
+            <option value="Goa">Goa</option>
+            <option value="Gujarat">Gujarat</option>
+            <option value="Haryana">Haryana</option>
+            <option value="Himachal Pradesh">Himachal Pradesh</option>
+            <option value="Jharkhand">Jharkhand</option>
+            <option value="Karnataka">Karnataka</option>
+            <option value="Kerala">Kerala</option>
+            <option value="Madhya Pradesh">Madhya Pradesh</option>
+            <option value="Maharashtra">Maharashtra</option>
+            <option value="Manipur">Manipur</option>
+            <option value="Meghalaya">Meghalaya</option>
+            <option value="Mizoram">Mizoram</option>
+            <option value="Nagaland">Nagaland</option>
+            <option value="Odisha">Odisha</option>
+            <option value="Punjab">Punjab</option>
+            <option value="Rajasthan">Rajasthan</option>
+            <option value="Sikkim">Sikkim</option>
+            <option value="Tamil Nadu">Tamil Nadu</option>
+            <option value="Telangana">Telangana</option>
+            <option value="Tripura">Tripura</option>
+            <option value="Uttar Pradesh">Uttar Pradesh</option>
+            <option value="Uttarakhand">Uttarakhand</option>
+            <option value="West Bengal">West Bengal</option>
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">Capital</label>
+          <input
+            type="text"
+            name="capital"
+            className="form-input"
+            value={formData.capital}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">Segment</label>
+          <input
+            type="text"
+            name="segment"
+            className="form-input"
+            value={formData.segment}
+            onChange={handleChange}
           />
         </div>
 

--- a/src/pages/LeadsPage.tsx
+++ b/src/pages/LeadsPage.tsx
@@ -381,6 +381,12 @@ function LeadsPage() {
             <p><strong>Full Name:</strong> {infoLead.fullName}</p>
             <p><strong>Email:</strong> {infoLead.email}</p>
             <p><strong>Phone:</strong> {infoLead.phone || '—'}</p>
+            <p><strong>Alternate Number:</strong> {infoLead.altNumber || '—'}</p>
+            <p><strong>Deemat Account:</strong> {infoLead.deematAccountName || '—'}</p>
+            <p><strong>Profession:</strong> {infoLead.profession || '—'}</p>
+            <p><strong>State:</strong> {infoLead.stateName || '—'}</p>
+            <p><strong>Capital:</strong> {infoLead.capital || '—'}</p>
+            <p><strong>Segment:</strong> {infoLead.segment || '—'}</p>
             <p><strong>Status:</strong> {infoLead.status}</p>
             <p><strong>Team:</strong> {teams.find(t => t.id === infoLead.team_id)?.name || '—'}</p>
             <p><strong>Notes:</strong> {infoLead.notes || '—'}</p>

--- a/src/stores/leadStore.ts
+++ b/src/stores/leadStore.ts
@@ -7,7 +7,13 @@ export interface Lead {
   fullName: string;
   phone: string;
   email: string;
+  altNumber: string;
   notes: string;
+  deematAccountName: string;
+  profession: string;
+  stateName: string;
+  capital: string;
+  segment: string;
   status: 'New' | 'Contacted' | 'Qualified' | 'Proposal' | 'Won' | 'Lost';
   team_id: string;
   assigned_to?: string;
@@ -33,7 +39,13 @@ export const useLeadStore = create<LeadStore>((set) => ({
       const { data } = await axios.get('/api/leads');
       const mapped = data.map((lead: any) => ({
         ...lead,
-        fullName: lead.full_name, // ✅ map to camelCase
+        fullName: lead.full_name,
+        altNumber: lead.alt_number,
+        deematAccountName: lead.deemat_account_name,
+        profession: lead.profession,
+        stateName: lead.state_name,
+        capital: lead.capital,
+        segment: lead.segment
       }));
       set({ leads: mapped });
     } catch (err) {


### PR DESCRIPTION
## Summary
- extend `Lead` type to support Demat account, profession, state, capital, alt number and segment
- show and edit these new fields in the Lead modal and info modal
- map the new columns when fetching leads
- update backend lead controller to handle new columns for create, update and uploads

## Testing
- `npx tsc --noEmit` *(fails: npm cannot run offline)*

------
https://chatgpt.com/codex/tasks/task_e_68615776c2c08328a2302fd107ab0a91