### PR TITLE
Hide won leads in leads page

### DIFF
--- a/src/pages/LeadsPage.tsx
+++ b/src/pages/LeadsPage.tsx
@@ -155,6 +155,8 @@ function LeadsPage() {
   };
 
   const filteredLeads = leads.filter((lead) => {
+  // Hide leads that have been converted to clients
+  if (lead.status === 'Won') return false;
   if (role === 'relationship_mgr' && lead.assigned_to !== userId) return false;
   if (role === 'team_leader' && lead.team_id !== users.find(u => u.id === userId)?.team_id) return false;
   if (statusFilter === 'assigned' && !lead.assigned_to) return false;


### PR DESCRIPTION
## Summary
- hide leads marked as `Won` on the main leads list

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6862bbb64e708328833c6b3e742f23ff