### PR TITLE
Fix dashboard paid clients count

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -31,7 +31,7 @@ const Dashboard = () => {
   const totalLeads = filteredLeads.length;
   const totalTeams = teams.length;
 
-  const paidClients = filteredLeads.filter(l => l.status === 'Won' && l.paymentHistory && l.paymentHistory.trim() !== '').length;
+  const paidClients = filteredLeads.filter(l => l.status === 'Won').length;
   const totalSales = filteredLeads.reduce((sum, lead) => {
     if (lead.status === 'Won' && lead.paymentHistory) {
       return sum + lead.paymentHistory.split('|||').reduce((s, ph) => s + parseFloat(ph.split('__')[0] || '0'), 0);


### PR DESCRIPTION
## Summary
- compute paid clients based solely on leads with the 'Won' status

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68638bf5f0e48328af5c273e8af4a27c