### PR TITLE
Add sticky headers to tables

### DIFF
--- a/src/pages/Clientpage.tsx
+++ b/src/pages/Clientpage.tsx
@@ -40,9 +40,9 @@ const ClientsPage = () => {
       {wonLeads.length === 0 ? (
         <p className="text-gray-400">No leads have been marked as "Won" yet.</p>
       ) : (
-        <div className="overflow-x-auto bg-gray-800 rounded-lg border border-gray-700">
+        <div className="overflow-x-auto bg-gray-800 rounded-lg border border-gray-700 max-h-[60vh]">
           <table className="min-w-full text-sm text-left text-gray-300">
-            <thead className="bg-gray-700 text-xs uppercase text-gray-400">
+            <thead className="bg-gray-700 text-xs uppercase text-gray-400 sticky top-0">
               <tr>
                 <th className="p-3">Full Name</th>
                 <th className="p-3">Email</th>

--- a/src/pages/LeadsPage.tsx
+++ b/src/pages/LeadsPage.tsx
@@ -261,9 +261,9 @@ function LeadsPage() {
       )}
 
       <div className="bg-gray-800 rounded-lg overflow-hidden">
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto max-h-[60vh]">
           <table className="table-fixed w-full text-sm text-left text-gray-300">
-            <thead className="bg-gray-700 text-gray-400 uppercase text-xs">
+            <thead className="bg-gray-700 text-gray-400 uppercase text-xs sticky top-0">
               <tr>
                 <th className="w-10 p-3">
                   <input

--- a/src/pages/TeamsPage.tsx
+++ b/src/pages/TeamsPage.tsx
@@ -57,9 +57,9 @@ function TeamsPage() {
       </div>
 
       <div className="bg-gray-800 rounded-lg overflow-hidden">
-        <div className="table-container">
+        <div className="table-container max-h-[60vh] overflow-y-auto">
           <table className="data-table">
-            <thead className="bg-gray-700">
+            <thead className="bg-gray-700 sticky top-0">
               <tr>
                 <th>Team Name</th>
                 <th>Users</th>

--- a/src/pages/UsersPage.tsx
+++ b/src/pages/UsersPage.tsx
@@ -88,9 +88,9 @@ function UsersPage() {
         )}
       </div>
 
-      <div className="overflow-hidden border border-gray-700 rounded-lg">
+      <div className="overflow-x-auto max-h-[60vh] border border-gray-700 rounded-lg">
         <table className="min-w-full text-sm text-left text-gray-300">
-          <thead className="bg-gray-700 uppercase text-xs text-gray-400">
+          <thead className="bg-gray-700 uppercase text-xs text-gray-400 sticky top-0">
             <tr>
               <th className="p-3">Name</th>
               <th className="p-3">Email</th>


### PR DESCRIPTION
## Summary
- make table headers sticky so data scrolls independently on UsersPage, LeadsPage, TeamsPage, and ClientsPage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68639017832483289bd5b9dc7dbdec1b