### PR TITLE
Add team-specific lead view for team leaders

### DIFF
--- a/Backend/controllers/leads.js
+++ b/Backend/controllers/leads.js
@@ -23,6 +23,25 @@ const getLeads = async (req, res) => {
          ORDER BY l.date DESC`,
         [user_id]
       );
+    } else if (role === 'team_leader') {
+      const teamRes = await pool.query(
+        'SELECT team_id FROM users WHERE id = $1',
+        [user_id]
+      );
+      const teamId = teamRes.rows[0]?.team_id;
+
+      if (teamId) {
+        result = await pool.query(
+          `SELECT l.*, u.display_name AS assigned_user_name, u.role AS assigned_user_role
+           FROM leads l
+           LEFT JOIN users u ON l.assigned_to = u.id
+           WHERE l.team_id = $1
+           ORDER BY l.date DESC`,
+          [teamId]
+        );
+      } else {
+        result = { rows: [] };
+      }
     } else if (role === 'admin') {
       result = await pool.query(
         `SELECT l.*, u.display_name AS assigned_user_name, u.role AS assigned_user_role


### PR DESCRIPTION
## Summary
- restrict `getLeads` results for team_leader role to leads belonging to the leader's team

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686396d9dcf08328ae3293be314a3b13