### PR TITLE
Filter dashboard data for team leader

### DIFF
--- a/Backend/controllers/leads.js
+++ b/Backend/controllers/leads.js
@@ -23,6 +23,25 @@ const getLeads = async (req, res) => {
          ORDER BY l.date DESC`,
         [user_id]
       );
+    } else if (role === 'team_leader') {
+      const teamRes = await pool.query(
+        'SELECT team_id FROM users WHERE id = $1',
+        [user_id]
+      );
+      const teamId = teamRes.rows[0]?.team_id;
+
+      if (teamId) {
+        result = await pool.query(
+          `SELECT l.*, u.display_name AS assigned_user_name, u.role AS assigned_user_role
+           FROM leads l
+           LEFT JOIN users u ON l.assigned_to = u.id
+           WHERE l.team_id = $1
+           ORDER BY l.date DESC`,
+          [teamId]
+        );
+      } else {
+        result = { rows: [] };
+      }
     } else if (role === 'admin') {
       result = await pool.query(
         `SELECT l.*, u.display_name AS assigned_user_name, u.role AS assigned_user_role

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -63,7 +63,7 @@ const Dashboard = () => {
     }));
 
   const rmSales = users
-    .filter(u => u.role === 'relationship_mgr')
+    .filter(u => u.role === 'relationship_mgr' && (role !== 'team_leader' || u.team_id === teamId))
     .map(rm => {
       const rmLeads = filteredLeads.filter(l => l.assigned_to === rm.id && l.status === 'Won');
       const sales = rmLeads.reduce((sum, lead) => {


### PR DESCRIPTION
## Summary
- filter leads by leader's team on backend
- limit RM sales to leader's team on dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863b33bb2cc83288da19db88e8c9dcb